### PR TITLE
Switch git proto to https

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,5 +2,5 @@
 {erl_opts, [debug_info, warnings_as_errors]}.
 {cover_enabled, true}.
 {deps, [
-    {pmod_transform, ".*", {git, "git://github.com/erlang/pmod_transform.git", {branch, master}}}
+    {pmod_transform, ".*", {git, "https://github.com/erlang/pmod_transform", {branch, master}}}
 ]}.


### PR DESCRIPTION
`rebar3 deps get` can't download this via git protocol. changed to https.